### PR TITLE
fix parsing issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "tbela99/css",
   "description": "A CSS parser and minifier written in PHP",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "library",
   "keywords": [
     "CSS",

--- a/src/TBela/CSS/Parser/ParserTrait.php
+++ b/src/TBela/CSS/Parser/ParserTrait.php
@@ -181,6 +181,11 @@ trait ParserTrait
         $count = 1;
         $i = $start;
 
+        if (\substr($string, $start, 1) === $search) {
+
+            return $search;
+        }
+
         while (++$i <= $end) {
 
             switch ($string[$i]) {

--- a/src/TBela/CSS/Value/CssString.php
+++ b/src/TBela/CSS/Value/CssString.php
@@ -24,7 +24,7 @@ class CssString extends Value
             $data->q = $q;
             $data->value = substr($data->value, 1, -1);
 
-            if (preg_match('#^[\w_-]+$#', $data->value)) {
+            if (preg_match('#^[\w_-]+$#', $data->value) && !is_numeric(\substr($data->value, 0 , 1))) {
 
                 $data->q = '';
             }

--- a/test/src/CssIdentifier.php
+++ b/test/src/CssIdentifier.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use TBela\CSS\Parser;
+use TBela\CSS\Renderer;
+
+final class CssIdentifier extends TestCase
+{
+    /**
+     * @param string $expected
+     * @param string $actual
+     * @dataProvider identifierProvider
+     */
+    public function testIdentifier($expected, $actual): void
+    {
+
+        $this->assertEquals(
+            $expected,
+          $actual
+        );
+    }
+
+
+    public function identifierProvider() {
+
+        $data = [];
+
+        $data[] = [(string) (new Parser('div[data-elem-id="1587819236980"]{
+background:red;
+}'))->parse(), 'div[data-elem-id="1587819236980"] {
+ background: red
+}'];
+
+        return $data;
+    }
+}
+

--- a/test/src/CssIdentifier.php
+++ b/test/src/CssIdentifier.php
@@ -32,6 +32,12 @@ background:red;
  background: red
 }'];
 
+        $data[] = [(string) (new Parser('div[data-elem-id="a1587819236980"]{
+background:red;
+}'))->parse(), 'div[data-elem-id=a1587819236980] {
+ background: red
+}'];
+
         return $data;
     }
 }

--- a/test/src/Parse.php
+++ b/test/src/Parse.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use TBela\CSS\Parser;
+use TBela\CSS\Renderer;
+
+final class Parse extends TestCase
+{
+    /**
+     * @param string $expected
+     * @param string $actual
+     * @dataProvider parseProvider
+     */
+    public function testParse($expected, $actual): void
+    {
+
+        $this->assertEquals(
+            $expected,
+          $actual
+        );
+    }
+
+
+    public function parseProvider() {
+
+        $data = [];
+
+        $data[] = [(string) (new Parser('#test .test2{}#test3 .test4{}'))->parse(), '#test .test2 {
+
+}
+#test3 .test4 {
+
+}'];
+
+        $data[] = [(string) (new Parser('#test .test2{}#test3 .test4{color:scroll;}'))->parse(), '#test .test2 {
+
+}
+#test3 .test4 {
+ color: scroll
+}'];
+
+        return $data;
+    }
+}
+


### PR DESCRIPTION
- preserve quotes around string when it starts with a number #40
- incorrectly match '}' #40 