### PR TITLE
Remove an optimisation which breaks relative URLs

### DIFF
--- a/src/Parser/Helper.php
+++ b/src/Parser/Helper.php
@@ -265,11 +265,6 @@ class Helper
             }
         }
 
-        if (count($file) < count($ref)) {
-
-            return static::toUrl($fileUrl);
-        }
-
         while ($ref) {
 
             $r = $ref[0];


### PR DESCRIPTION
This optimisation disables relative paths when the output path is longer than the input path - but the result of that is that the generated CSS ends up pointing to URLs that are relative to the current directory instead of being relative to the generated CSS file.

input: test-in/style.css
```css
.foo { background-image: url("./local.png"); }
```

When writing to an output directory which is less than or equal to the depth of the input, the path to the file is relative to the output .css

output: test-out/style.css
```css
.foo { background-image: url("../test-in/local.png"); }
```

When writing to an output directory which is deeper than the input, relativity is disabled, and the path is broken

output: test-out/nested/path/style.css
```css
.foo { background-image: url("test-in/local.png"); }
```