### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/ArrayTrait.php
+++ b/src/ArrayTrait.php
@@ -44,7 +44,7 @@ trait ArrayTrait
      * @param string $value
      * @ignore
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
 
         if (is_callable([$this, 'set' . $offset])) {
@@ -58,7 +58,7 @@ trait ArrayTrait
      * @return bool
      * @ignore
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return is_callable([$this, 'get' . $offset]) ||
             is_callable([$this, 'set' . $offset]) ||
@@ -69,7 +69,7 @@ trait ArrayTrait
      * @param string $offset
      * @ignore
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
 
         if (is_callable([$this, 'set' . $offset])) {
@@ -83,7 +83,7 @@ trait ArrayTrait
      * @return mixed|null
      * @ignore
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
 
         if (is_callable([$this, 'get' . $offset])) {

--- a/src/Element.php
+++ b/src/Element.php
@@ -613,7 +613,7 @@ abstract class Element implements ElementInterface, \Stringable  {
      * @return stdClass
      * @ignore
      */
-    public function jsonSerialize () {
+    public function jsonSerialize (): mixed {
 
         return $this->getAst();
     }

--- a/src/Element/AtRule.php
+++ b/src/Element/AtRule.php
@@ -100,7 +100,7 @@ class AtRule extends RuleSet {
      * @return \stdClass
      * @ignore
      */
-    public function jsonSerialize () {
+    public function jsonSerialize (): mixed {
 
         $ast = parent::jsonSerialize();
 

--- a/src/Element/NestingRule.php
+++ b/src/Element/NestingRule.php
@@ -10,7 +10,7 @@ class NestingRule extends Rule
     /**
      * @inheritDoc
      */
-    public function support(ElementInterface $child)
+    public function support(ElementInterface $child): bool
     {
 
         return true;

--- a/src/Element/RuleList.php
+++ b/src/Element/RuleList.php
@@ -281,7 +281,7 @@ abstract class RuleList extends Element implements RuleListInterface
      * return an iterator of child nodes
      * @return ArrayIterator|Traversable
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
 
         return new ArrayIterator($this->ast->children ?? []);

--- a/src/Parser/AccessTrait.php
+++ b/src/Parser/AccessTrait.php
@@ -52,7 +52,7 @@ trait AccessTrait
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Property/PropertyList.php
+++ b/src/Property/PropertyList.php
@@ -360,7 +360,7 @@ class PropertyList implements IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return $this->getProperties();
     }

--- a/src/Value.php
+++ b/src/Value.php
@@ -581,13 +581,13 @@ abstract class Value implements JsonSerializable, ObjectInterface
             return $string;
         }
 
-        if (trim($property) === '') {
+        if (trim((string)$property) === '') {
 
             $property = null;
         }
 
         $string = trim($string);
-        $property = strtolower($property);
+        $property = strtolower((string)$property);
 
         if ($property !== '') {
 
@@ -1466,7 +1466,7 @@ abstract class Value implements JsonSerializable, ObjectInterface
         return $this->render();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->render();
     }


### PR DESCRIPTION
Using php 8.2 I'm getting a ton of error messages in my logs like:
```
Deprecated: Return type of TBela\CSS\Element::offsetUnset($offset) should
either be compatible with ArrayAccess::offsetUnset(mixed $offset): void,
or the #[\ReturnTypeWillChange] attribute should be used to temporarily
suppress the notice in [...]/src/ArrayTrait.php on line 72
```
and
```
Deprecated: strtolower(): Passing null to parameter #1 ($string) of type
string is deprecated in [...]/src/Value.php on line 590
```
I'm not sure if this will break compatibility with php 8.0, I hope that the automated test suite will say if that's the case (if so, maybe the `#[\ReturnTypeWillChange]` approach would work?)

There are still two deprecation warnings coming from the upstream `opis/closure` library though...