### PR TITLE
Fix return type of TBela\CSS\Property\Property::offsetSet(, ) should …

### DIFF
--- a/src/ArrayTrait.php
+++ b/src/ArrayTrait.php
@@ -44,6 +44,7 @@ trait ArrayTrait
      * @param string $value
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
 
@@ -58,6 +59,7 @@ trait ArrayTrait
      * @return bool
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return is_callable([$this, 'get' . $offset]) ||
@@ -69,6 +71,7 @@ trait ArrayTrait
      * @param string $offset
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
 
@@ -83,6 +86,7 @@ trait ArrayTrait
      * @return mixed|null
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
 

--- a/src/Element.php
+++ b/src/Element.php
@@ -613,6 +613,7 @@ abstract class Element implements ElementInterface, \Stringable  {
      * @return stdClass
      * @ignore
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize () {
 
         return $this->getAst();

--- a/src/Element/RuleList.php
+++ b/src/Element/RuleList.php
@@ -281,6 +281,7 @@ abstract class RuleList extends Element implements RuleListInterface
      * return an iterator of child nodes
      * @return ArrayIterator|Traversable
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
 

--- a/src/Property/PropertyList.php
+++ b/src/Property/PropertyList.php
@@ -360,6 +360,7 @@ class PropertyList implements IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getProperties();

--- a/src/Value.php
+++ b/src/Value.php
@@ -1466,6 +1466,7 @@ abstract class Value implements JsonSerializable, ObjectInterface
         return $this->render();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->render();


### PR DESCRIPTION
…either be compatible with ArrayAccess::offsetSet(mixed , mixed ): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice